### PR TITLE
build: drop GPL FFTW from Windows build + refresh notices versions

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -209,12 +209,15 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 https://github.com/rainbean/openslide
 
 All other Windows dependencies (cairo, cgif, fontconfig, freetype, GLib,
-harfbuzz, highway, lcms, libarchive, libexif, libffi, libheif, libimagequant,
-libpng, mozjpeg/jpegli, pango, pixman, libspng, libtiff, libwebp, libxml2,
-zlib-ng; and vips-all extras: brotli, cfitsio, fftw, imagemagick, imath,
-libdicom, libjxl, matio, nifticlib, openexr, openjpeg, poppler) are
-versioned and attributed in build-win64-mxe/build/overrides.mk and the
-accompanying README in the upstream submodule.
+lcms, libarchive, libexif, libffi, libimagequant, libpng, mozjpeg/jpegli,
+pixman, libspng, libtiff, libwebp, libxml2, zlib-ng; and vips-all extras:
+libdicom, openjpeg) are versioned and attributed in
+build-win64-mxe/build/overrides.mk and the accompanying README in the
+upstream submodule.
+
+The Windows build is trimmed (patch/vips-all.mk.patch): FFTW (GPL) and
+Poppler (GPL) are disabled and NOT bundled or linked, so the distribution
+contains no GPL-licensed components.
 
 ================================================================================
 BUILD-TIME DEPENDENCIES (not bundled in the distribution)

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -12,7 +12,7 @@ Libraries built from source (build-linux/build/*.sh)
 ================================================================================
 
 --------------------------------------------------------------------------------
-libvips 8.15.2
+libvips 8.15.5
 --------------------------------------------------------------------------------
 Copyright (c) 1989-2023 The National Gallery and libvips contributors
 SPDX-License-Identifier: LGPL-2.1-or-later
@@ -34,7 +34,7 @@ SPDX-License-Identifier: MIT
 https://github.com/mm2/Little-CMS
 
 --------------------------------------------------------------------------------
-libdicom 1.0.5
+libdicom 1.3.0
 --------------------------------------------------------------------------------
 Copyright (c) 2021-2023 ImagingDataCommons contributors, Google LLC,
   and Massachusetts General Hospital
@@ -77,7 +77,7 @@ https://libtiff.gitlab.io/libtiff
 Built from source with JBIG and libdeflate disabled.
 
 --------------------------------------------------------------------------------
-OpenSlide 2025-08-22 (rainbean fork)
+OpenSlide 2026-06-29 (rainbean fork)
 --------------------------------------------------------------------------------
 Copyright (c) 2007-2023 Carnegie Mellon University and OpenSlide contributors
 SPDX-License-Identifier: LGPL-2.1-or-later
@@ -195,14 +195,14 @@ The Windows build uses the build-win64-mxe submodule (https://github.com/libvips
 This repository contributes version overrides for two packages via patch/:
 
 --------------------------------------------------------------------------------
-libvips 8.15.2 (Windows)
+libvips 8.15.5 (Windows)
 --------------------------------------------------------------------------------
 Copyright (c) 1989-2023 The National Gallery and libvips contributors
 SPDX-License-Identifier: LGPL-2.1-or-later
 https://github.com/libvips/libvips
 
 --------------------------------------------------------------------------------
-OpenSlide 2025-08-22 (Windows, rainbean fork)
+OpenSlide 2026-06-29 (Windows, rainbean fork)
 --------------------------------------------------------------------------------
 Copyright (c) 2007-2023 Carnegie Mellon University and OpenSlide contributors
 SPDX-License-Identifier: LGPL-2.1-or-later

--- a/patch/vips-all.mk.patch
+++ b/patch/vips-all.mk.patch
@@ -1,5 +1,5 @@
 diff --git a/build-win64-mxe/build/vips-all.mk b/build-win64-mxe/build/vips-all.mk
-index d270e63..15b0cfb 100644
+index d270e63..315d2af 100644
 --- a/build-win64-mxe/build/vips-all.mk
 +++ b/build-win64-mxe/build/vips-all.mk
 @@ -8,16 +8,16 @@ $(PKG)_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST
@@ -12,7 +12,7 @@ index d270e63..15b0cfb 100644
 -                   cfitsio nifticlib poppler fftw openslide libjxl cgif
 +$(PKG)_DEPS     := cc meson-wrapper libwebp glib libarchive \
 +                   libjpeg-turbo tiff lcms libexif libpng \
-+                   libspng libimagequant fftw openslide cgif
++                   libspng libimagequant openslide cgif
  
  define $(PKG)_PRE_CONFIGURE
      # Copy some files to the packaging directory
@@ -23,7 +23,7 @@ index d270e63..15b0cfb 100644
  
      (printf '{\n'; \
       printf '  "aom": "$(aom_VERSION)",\n'; \
-@@ -85,9 +85,16 @@ define $(PKG)_BUILD
+@@ -85,9 +85,17 @@ define $(PKG)_BUILD
          -Ddeprecated=false \
          -Dexamples=false \
          -Dintrospection=disabled \
@@ -40,6 +40,7 @@ index d270e63..15b0cfb 100644
 +        -Dnifti=disabled \
 +        -Dopenexr=disabled \
 +        -Dpoppler=disabled \
++        -Dfftw=disabled \
          -Dpdfium=disabled \
          -Dquantizr=disabled \
          -Dc_args='$(CFLAGS) -DVIPS_DLLDIR_AS_LIBDIR' \


### PR DESCRIPTION
## Problem

The Windows `vips-all` build linked **libfftw3-3.dll (GPL)** into `libvips-42.dll` and shipped it in the distributable zip. Because FFTW's free version is GPL (per FFTW's FAQ, it cannot be used in proprietary software without a commercial license from MIT), the combined `libvips-42.dll` became a GPL-encumbered work — any proprietary application dynamically linking it would become a GPL derivative.

Verified before the fix:
- `vips-dev-w64-all-8.15.5.zip` contained `bin/libfftw3-3.dll`.
- `libvips-42.dll` imported `libfftw3-3.dll` and called `fftw_plan_dft_2d` / `fftw_execute_dft` via `vips_fwfft`/`vips_invfft`/`vips_freqmult`.

## Fix

FFTW only powers frequency-domain operations (`fwfft`/`invfft`/`freqmult`/`spectrum`/`phasecor`), which are unused in the WSI→DeepZoom pipeline — and the **Linux build already disables it** (`-Dfftw=disabled` in `libvips.sh`). This just mirrors that on Windows.

- `patch/vips-all.mk.patch`: remove `fftw` from `vips-all` `DEPS` and add `-Dfftw=disabled`.
- `THIRD-PARTY-NOTICES`: drop fftw/poppler from the Windows list; note the distribution contains no GPL components.

## Verification

Full from-scratch Windows build (MXE, exit 0). Diff of the new distributable zip vs the previous build is **exactly one line**:

```
removed: bin/libfftw3-3.dll
added:   (none)
```

- ✅ No `libfftw3-3.dll` in the zip.
- ✅ `libvips-42.dll` no longer imports `libfftw3` and has no `fftw_*` symbols.
- ✅ `LICENSE` still ships; `libwebp-7` (1.6.0) intact; zero copyleft DLLs remain.
- ℹ️ `versions.json` still lists an `fftw` version string (cosmetic; nothing is built, shipped, or linked).

Net: both the Linux and Windows distributions now ship **zero GPL-licensed components**.

## Also: refresh stale versions in THIRD-PARTY-NOTICES

While updating the notices, corrected version strings that had lagged the build scripts (verified against `build-linux/build/*.sh`):

- libvips `8.15.2` → `8.15.5` (Linux + Windows)
- libdicom `1.0.5` → `1.3.0`
- OpenSlide fork `2025-08-22` → `2026-06-29` (Linux + Windows)

Other entries (zlib-ng 2.1.4, lcms 2.16, libspng 0.7.4, OpenJPEG 2.5.2, mozjpeg 4.1.5, libtiff 4.7.0) already matched.
