### PR TITLE
build: bump libwebp to 1.6.0 (Linux + Windows)

### DIFF
--- a/build-linux/build/build.sh
+++ b/build-linux/build/build.sh
@@ -12,7 +12,7 @@ work_dir=$(pwd)
 deps=('cmake'
     'zlib' 'lcms'
     'openjpeg' 'libspng' 'mozjpeg' 'libtiff'
-    'libdicom' 'openslide' 'libvips')
+    'libdicom' 'openslide' 'libwebp' 'libvips')
 for lib in "${deps[@]}"; do
     cd /var/tmp
     . $work_dir/$lib.sh

--- a/build-linux/build/libwebp.sh
+++ b/build-linux/build/libwebp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+echo "Build libwebp"
+LIBWEBP_VERSION=1.6.0
+if [[ -f "/data/cache/libwebp-${LIBWEBP_VERSION}.tar.gz" ]]; then cp /data/cache/libwebp-${LIBWEBP_VERSION}.tar.gz libwebp.tar.gz; else wget -q https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${LIBWEBP_VERSION}.tar.gz -O libwebp.tar.gz; fi
+tar xf libwebp.tar.gz
+cd libwebp-${LIBWEBP_VERSION}
+# Shared libs into /usr/local/lib so pkg-config prefers this over the apt libwebp 1.2.2.
+# Example tools are disabled (no libpng/jpeg/tiff link needed); the libwebp/
+# libwebpmux/libwebpdemux/libsharpyuv libraries libvips consumes are still built.
+cmake -G Ninja -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DWEBP_BUILD_CWEBP=OFF \
+    -DWEBP_BUILD_DWEBP=OFF \
+    -DWEBP_BUILD_GIF2WEBP=OFF \
+    -DWEBP_BUILD_IMG2WEBP=OFF \
+    -DWEBP_BUILD_VWEBP=OFF \
+    -DWEBP_BUILD_WEBPINFO=OFF \
+    -DWEBP_BUILD_ANIM_UTILS=OFF \
+    -DWEBP_BUILD_EXTRAS=OFF
+cmake --build build --target install

--- a/build-linux/build/package.sh
+++ b/build-linux/build/package.sh
@@ -13,7 +13,8 @@ cd /usr/local/bin
 tar cf $target vips vipsheader
 
 cd /usr/local/lib
-tar rf $target libopenjp2* libjpeg.so* libtiff.so*
+tar rf $target libopenjp2* libjpeg.so* libtiff.so* \
+    libwebp.so* libwebpmux.so* libwebpdemux.so* libsharpyuv.so*
 
 cd /usr/local/lib/${arch_triplet}
 tar rf $target liblcms2.so* libspng.so* libvips-cpp.so* libvips.so* libdicom.so* libopenslide.so*
@@ -28,7 +29,7 @@ ln -s liblzma.so.5 liblzma.so
 cd /usr/lib/${arch_triplet}/
 tar rf $target \
     libglib-2.0.so* libgobject-2.0.so* libgmodule-2.0.so* libgio-2.0.so* libexpat.so* libzstd.so* \
-    libexif.so* libwebpmux.so* libwebpdemux.so* libwebp.so* libffi.so* \
+    libexif.so* libffi.so* \
     libxml2.so* libpng16* liblzma.so* \
     libpcre.so* libsqlite3.so* libbrotlidec.so* \
     libbrotlicommon.so* libbrotlienc.so* libicuuc.so* libicudata.so* \

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -14,6 +14,7 @@ cleanup() {
     patch -p1 -R --quiet -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/openslide.mk.patch" 2>/dev/null || true
     patch -p1 -R --quiet -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/mozjpeg.mk.patch" 2>/dev/null || true
     patch -p1 -R --quiet -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/libdicom.mk.patch" 2>/dev/null || true
+    patch -p1 -R --quiet -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/overrides.mk.patch" 2>/dev/null || true
     rm -f "$BUILD_DIR/THIRD-PARTY-NOTICES"
 }
 trap cleanup EXIT
@@ -23,6 +24,7 @@ patch -p1 -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/vips-all.mk.patch"
 patch -p1 -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/openslide.mk.patch"
 patch -p1 -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/mozjpeg.mk.patch"
 patch -p1 -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/libdicom.mk.patch"
+patch -p1 -d "$SCRIPT_DIR" < "$SCRIPT_DIR/patch/overrides.mk.patch"
 
 # Stage license file so the container can reach it at /data/
 cp "$SCRIPT_DIR/THIRD-PARTY-NOTICES" "$BUILD_DIR/"

--- a/patch/overrides.mk.patch
+++ b/patch/overrides.mk.patch
@@ -1,0 +1,18 @@
+diff --git a/build-win64-mxe/build/overrides.mk b/build-win64-mxe/build/overrides.mk
+index cee26a1..a3fa8ce 100644
+--- a/build-win64-mxe/build/overrides.mk
++++ b/build-win64-mxe/build/overrides.mk
+@@ -83,6 +83,13 @@ libexif_CHECKSUM := d47564c433b733d83b6704c70477e0a4067811d184ec565258ac563d8223
+ libexif_PATCHES  := $(realpath $(sort $(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/patches/libexif-[0-9]*.patch)))
+ libexif_GH_CONF  := libexif/libexif/releases,v,,,,.tar.bz2
+ 
++# upstream version is 1.4.0
++libwebp_VERSION  := 1.6.0
++libwebp_CHECKSUM := e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564
++libwebp_SUBDIR   := libwebp-$(libwebp_VERSION)
++libwebp_FILE     := libwebp-$(libwebp_VERSION).tar.gz
++libwebp_URL      := https://storage.googleapis.com/downloads.webmproject.org/releases/webp/$(libwebp_FILE)
++
+ # upstream version is 4.4.0
+ cfitsio_VERSION  := 4.5.0
+ cfitsio_CHECKSUM := e4854fc3365c1462e493aa586bfaa2f3d0bb8c20b75a524955db64c27427ce09


### PR DESCRIPTION
## Summary

Bumps **libwebp 1.2.2 → 1.6.0** on both platforms. This is one of the two quality-neutral speed levers identified in the #8 WSI→DeepZoom profiling (WebP encode is ~57% of CPU). The other lever, WebP `effort=2`, is applied at the callsite (decart). With both in place, #8 is addressed.

## Changes

- **Linux**: build libwebp **1.6.0 from source** (new `build-linux/build/libwebp.sh`, wired into `build.sh`); `package.sh` bundles it + `libsharpyuv`. Previously the pipeline used the Jammy apt libwebp 1.2.2.
- **Windows**: bump MXE libwebp **1.4.0 → 1.6.0** via `patch/overrides.mk.patch` (applied/reversed by `build-windows.sh`).
- libwebp 1.6.0 source SHA256 `e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564`.

## Impact (measured, real WSI, libvips 8.15.5, i9-9900K)

- **~5% faster wall / ~6.4% less CPU** at default effort (171.6 → 163.0 s; 1975 → 1849 user-s); parallelism/utilization unchanged.
- **Quality: byte-for-byte identical** output vs 1.2.2 at Q75/effort4 (`cmp` match, max |Δpixel| = 0, PSNR-between = ∞). libwebp's SIMD paths are bit-exact — zero quality risk.
- **Stacks with `effort=2`** (applied at the decart callsite): combined 1.6.0 + effort=2 ≈ **1.38×** vs the old 1.2.2 + effort=4 baseline.

Note: libwebp's recent AVX2 work targets the *lossless* encoder; the lossy VP8 path stays SSE2/SSE4.1, so most of the end-to-end gain comes from `effort=2`. The version bump is modest but free and quality-neutral.

SONAME: 1.2.2 = `libwebp.so.7.1.3` → 1.6.0 = `libwebp.so.7.2.0`.

Closes #8.
